### PR TITLE
ci!(.github/workflows): Migrate workflow to uv with OIDC

### DIFF
--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -16,7 +16,7 @@ permissions:
   contents: read
 
 jobs:
-  deploy:
+  release-build:
 
     runs-on: ubuntu-latest
 
@@ -33,11 +33,22 @@ jobs:
       with:
         python-version-file: "pyproject.toml"
 
-    - name: Install build dependencies
-      run: uv sync --all-extras
-
     - name: Build package
       run: uv build
+
+    - name: Upload distributions
+      uses: actions/upload-artifact@v4
+      with:
+        name: release-dists
+        path: dist/
+
+  pypi-publish:
+    runs-on: ubuntu-latest
+    needs:
+      - release-build
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
 
     - name: Publish package
       run: uv publish


### PR DESCRIPTION
BREAKING CHANGE: Migrate publishing to uv
Related to #8