### PR TITLE
ci(.github/workflows/publish_pypi): Switched to API based auth

### DIFF
--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -51,4 +51,4 @@ jobs:
       id-token: write
 
     - name: Publish package
-      run: uv publish
+      run: uv publish --token ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Related to #8