### PR TITLE
ci(.github/workflows/publish_pypi): Ensure UV installed for pypi CI

### DIFF
--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -53,5 +53,10 @@ jobs:
       - release-build
 
     steps:
+    - name: Install uv
+      uses: astral-sh/setup-uv@v6
+      with:
+        version: "latest"
+
     - name: Publish package
       run: uv publish --token ${{ secrets.PYPI_API_TOKEN }} dist/


### PR DESCRIPTION
Related to #8