### PR TITLE
Update README to indicate repository is unmaintained

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+*This repository is no longer maintained. Moreover, all improvements have been merged into the GSTT version of Hazen. Please see [https://github.com/GSTT-CSC/hazen](https://github.com/GSTT-CSC/hazen) for the most up-to-date version.*
+
 <!-- PROJECT HEADING -->
 <br />
 <p align="center">


### PR DESCRIPTION
- Added notice about repository maintenance status and link to GSTT version.
- I'd recommend making this repository a public archive as well. There are instructions on how to do this [here](https://docs.github.com/en/repositories/archiving-a-github-repository/archiving-repositories).